### PR TITLE
Check intent before loading receipt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 
     ext {
-        version_name = '3.0.2'
+        version_name = '3.0.3'
         kotlin_version = '1.3.21'
         compile_sdk_version = 28
         target_sdk_version = 28

--- a/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.kt
+++ b/library/src/main/java/pl/aprilapps/easyphotopicker/EasyImage.kt
@@ -261,7 +261,7 @@ class EasyImage private constructor(
 
     private fun onFileReturnedFromChooser(resultIntent: Intent?, activity: Activity, callbacks: Callbacks) {
         Log.d(EASYIMAGE_LOG_TAG, "File returned from chooser")
-        if (resultIntent != null) {
+        if (resultIntent != null && !Intents.isTherePhotoTakenWithCameraInsideIntent(resultIntent)) {
             onPickedExistingPictures(resultIntent, activity, callbacks)
             removeCameraFileAndCleanup()
         } else if (lastCameraFile != null) {


### PR DESCRIPTION
I noticed that for some devices when we choose camera app then activity result intent isn't null but empty. 
That is why we have to check if it contains any data inside. 
I found also the same pull request targeting original EasyImage repository. 
